### PR TITLE
Update node-sass dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's built on the [Express](http://expressjs.com/) framework and contains code a
 
 ## Requirements
 
-#### [Node](http://nodejs.org/)
+#### [Node v4.x.x](http://nodejs.org/)
 
 You may already have it, try:
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "description": "NHS prototyping app in Express",
   "version": "0.1.0",
   "private": true,
-  "engines": {
-    "node": "0.10.x"
-  },
   "dependencies": {
     "bluebird": "2.10.2",
     "consolidate": "0.x",
@@ -19,10 +16,10 @@
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-nodemon": "0.3.0",
-    "grunt-sass": "0.18.0",
+    "grunt-sass": "1.1.0",
     "grunt-text-replace": "0.3.12",
     "minimist": "0.0.8",
-    "node-sass": "2.1.1",
+    "node-sass": "3.4.2",
     "readdir": "0.0.6",
     "swig": "^1.4.2",
     "swig-extras": "0.0.1"


### PR DESCRIPTION
Selected this over the feature/update-sass-packages so that if a future merge with the upstream nhs_prototype_kit is required it will be easier I think.

---

When I upgraded to node v4.2.4 I encountered the problem documented
here:

https://github.com/sass/node-sass/issues/1166

Upgrading grunt-sass and node-sass, then removing `node_packages/` and
doing `$ npm install` fixed this issue for me.

Note I've also removed the `engines` value from `package.json` as it's
not clear that this is actually adding anything.
